### PR TITLE
Use https since it's available for github.io

### DIFF
--- a/css/developers.scss
+++ b/css/developers.scss
@@ -2,7 +2,7 @@
 # Compiled by jekyll
 ---
 
-$root: 'http://linode.github.io/developers/styles/';
+$root: 'https://linode.github.io/developers/styles/';
 @import "base";
 
 table {


### PR DESCRIPTION
Use https here since it's available from github.io and should stop browsers from warning about insecure content