### PR TITLE
Added conditional to prefix integers and arrays

### DIFF
--- a/_data/objects/dnszone.yaml
+++ b/_data/objects/dnszone.yaml
@@ -7,8 +7,6 @@ schema:
   id:
     _type: integer
     _value: 357
-    _description: >
-      string
   dnszone:
     _editable: true
     _type: string

--- a/_data/objects/dnszonerecord.yaml
+++ b/_data/objects/dnszonerecord.yaml
@@ -8,8 +8,6 @@ schema:
   id:
     _type: integer
     _value: 468
-    _description: >
-      string
   type:
     _type: string
     _value: A

--- a/_includes/render-property-table.html
+++ b/_includes/render-property-table.html
@@ -20,6 +20,8 @@
                 <span class="description">
                     {% if include.info._description %}
                     {{ include.info._description }}
+                    {% elsif include.info._type == 'integer' or include.info._type == 'array' %}
+                    An {{ include.info._type }}.
                     {% else %}
                     A {{ include.info._type }}.
                     {% endif %}


### PR DESCRIPTION
If a type is 'integer' or 'array' and no description provided,
the docs will now prefix the type with 'an' instead of 'a' to be
grammatically correct.