### PR TITLE
Restore FAQ link

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,3 +83,11 @@ layout: base
         </div>
     </div>
 </div>
+
+<div class="container cards-container">
+    <div class="row">
+        <div class="col-lg-12 col-md-12 text-xs-center">
+            <h4><a href="/faq.html">Frequently Asked Questions</a></h4>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
The FAQ is there - I think we just missed that it needs the extension (unlike /guides, /reference, /libraries etc. which are directories)