### PR TITLE
Removing large horizontal scrollbar from the ref pages

### DIFF
--- a/css/reference.scss
+++ b/css/reference.scss
@@ -180,6 +180,7 @@ nav{
 
 body {
     background: #f6f6f6;
+    overflow-x: hidden;
 }
 
 .elevated-content {


### PR DESCRIPTION
Probably not the best way to do this, as I should be removing the elements
that are causing this, but this accomplishes it for the time being.