### PR TITLE
Patch get dependencies

### DIFF
--- a/getDependencies.sh
+++ b/getDependencies.sh
@@ -16,7 +16,7 @@ curl https://developers.linode.com/api/docs/v4/openapi.yaml > src/data/openapi.y
 
 echo
 echo "${BLUE}Removing faulty data${NC}"
-sed -i '/backgroundColor:/d' src/data/openapi.yaml
+sed -i "" '/backgroundColor:/d' src/data/openapi.yaml
 
 echo
 echo "${BLUE}Converting YAML to JSON${NC}"

--- a/getDependencies.sh
+++ b/getDependencies.sh
@@ -16,7 +16,8 @@ curl https://developers.linode.com/api/docs/v4/openapi.yaml > src/data/openapi.y
 
 echo
 echo "${BLUE}Removing faulty data${NC}"
-sed -i "" '/backgroundColor:/d' src/data/openapi.yaml
+sed -i.bak '/backgroundColor:/d' src/data/openapi.yaml
+rm src/data/openapi.yaml.bak
 
 echo
 echo "${BLUE}Converting YAML to JSON${NC}"


### PR DESCRIPTION
The script was failing when run locally on a Mac since the OSX version of `sed` wasn't parsing the command correctly. This should (hopefully) work on both Mac and Linux.