### PR TITLE
[Update] Changelog for API Spec 4.4.0

### DIFF
--- a/src/content/changelog/2019-09-09-api.md
+++ b/src/content/changelog/2019-09-09-api.md
@@ -9,7 +9,7 @@ version: 4.4.0
 
 ### Added
 
-- Added a `secondary_entity` property to the [GET /account/events](/api/v4/account-events) and [GET /account/events/{eventId}](/api/v4/account-events-event-id) endpoints. A `secondary_entity` object displays information about an additional entity that is related to the Event. Currently, the `linode_boot`, `linode_create`, and `linode_clone` Event actions can generate a `secondary_entity` object of type `linode`, `image`, and `backup`.
+- Added a `secondary_entity` property to the [GET /account/events](/api/v4/account-events) and [GET /account/events/{eventId}](/api/v4/account-events-event-id) endpoints. A `secondary_entity` object displays information about an additional entity that is related to the Event. Currently, the `linode_boot`, `linode_create`, and `linode_clone` Event actions can generate a `secondary_entity` object.
 
 - Added convenience Object Storage beta endpoints for the Early Access Program. It is recommended to use the more fully-featured [S3 API](https://docs.ceph.com/docs/mimic/radosgw/s3/#) directly instead of these endpoints. **Note**: these endpoints are prepended with **`/v4beta`** instead of `/v4`.
 


### PR DESCRIPTION
Removed reference to possible returned entity types in `secondary_entity` changelog entry.