### PR TITLE
[Update] Remove sidebar APIv3 menu item

### DIFF
--- a/src/components/2_molecules/sidemenu.js
+++ b/src/components/2_molecules/sidemenu.js
@@ -21,7 +21,6 @@ const topMenuItems = [
   "Pagination",
   "Filtering and Sorting",
   "CLI (Command Line Interface)",
-  "APIv3"
 ];
 
 class SideMenu extends React.Component {


### PR DESCRIPTION
* Removed APIv3 link from API spec. This PR removes APIv3 as a sidebar menu item.
* When a new link is available, this will be added back in.