### PR TITLE
Release 1.1.9

### DIFF
--- a/src/components/2_molecules/sidemenu.js
+++ b/src/components/2_molecules/sidemenu.js
@@ -21,7 +21,6 @@ const topMenuItems = [
   "Pagination",
   "Filtering and Sorting",
   "CLI (Command Line Interface)",
-  "APIv3"
 ];
 
 class SideMenu extends React.Component {

--- a/src/content/changelog/4-11-0-2019-12-16.md
+++ b/src/content/changelog/4-11-0-2019-12-16.md
@@ -10,12 +10,12 @@ changelog:
 * The `View Account` ([GET /account](https://developers.linode.com/api/v4/account)) and the `Update Account` ([PUT /account](https://developers.linode.com/api/v4/account/#put)) endpoints have been updated to include a new field `euuid`. This field is an external unique identifier for this customer.
 * The following endpoints have the new field `last_successful` adedd to the `backups` envelope within the `Linode` object. This field is the date and time of the last successful backup if there was one. If there was no backup, 'null' is shown.
   * `List Linodes` ([GET /linode/instances](https://developers.linode.com/api/v4/linode-instances))
-  * `Create Linode` ([PUT /linode/instances](https://developers.linode.com/api/v4/linode-instances/#post))
+  * `Create Linode` ([POST /linode/instances](https://developers.linode.com/api/v4/linode-instances/#post))
   * `View Linode` ([GET /linode/instances/{linodeId}](https://developers.linode.com/api/v4/linode-instances-linode-id))
   * `Update Linode` ([PUT /linode/instances/{linodeId}](https://developers.linode.com/api/v4/linode-instances-linode-id/#put))
   * `Rebuild Linode` ([POST /linode/instances/{linodeId}/rebuild](https://developers.linode.com/api/v4/linode-instances-linode-id-rebuild/#post))
 * Added end of life to image endpoints. This displays the image's distribution's planned end of life. This `eol` response parameter has been added to the following endpoints:
-  * List Images ([GET /images](https://developers.linode.com/api/v4/images)])
+  * List Images ([GET /images](https://developers.linode.com/api/v4/images))
   * Create Image ([POST /images](https://developers.linode.com/api/v4/images#post))
   * View Image [(GET /images/:imageId)](https://developers.linode.com/api/v4/images-image-id)
   * Update Image [(PUT /images/:imageId)](https://developers.linode.com/api/v4/images-image-id#put)

--- a/src/content/changelog/4-11-0-2019-12-16.md
+++ b/src/content/changelog/4-11-0-2019-12-16.md
@@ -7,13 +7,13 @@ changelog:
 ---
 ### Added
 
-* The `View Account` ([GET /account](https://developers.linode.com/api/docs/v4/account)) and the `Update Account` ([PUT /account](https://developers.linode.com/api/docs/v4/account)) endpoints have been updated to include a new field `euuid`. This field is an external unique indentifier for this customer.
-* The following endpoints have the new field `last_successful` adedd to the `backups` envelope within the `Linode` object. This field is the date and time of the last successful backup if there was one. If there was no backup, 'None' is shown.
-  * `List Linodes` ([GET /linode/instances](https://developers.linode.com/api/docs/v4/linode/instances))
-  * `Create Linode` ([PUT /linode/instances](https://developers.linode.com/api/docs/v4/linode/instances))
-  * `View Linode` ([GET /linode/instances/{linodeId}](https://developers.linode.com/api/docs/v4/linode/instances/{linodeId}))
-  * `Update Linode` ([PUT /linode/instances/{linodeId}](https://developers.linode.com/api/docs/v4/linode/instances/{linodeId}))
-  * `Rebuild Linode` ([POST /linode/instances/{linodeId}/rebuild](https://developers.linode.com/api/docs/v4/linode/instances/{linodeId}/rebuild))
+* The `View Account` ([GET /account](https://developers.linode.com/api/v4/account)) and the `Update Account` ([PUT /account](https://developers.linode.com/api/v4/account/#put)) endpoints have been updated to include a new field `euuid`. This field is an external unique identifier for this customer.
+* The following endpoints have the new field `last_successful` adedd to the `backups` envelope within the `Linode` object. This field is the date and time of the last successful backup if there was one. If there was no backup, 'null' is shown.
+  * `List Linodes` ([GET /linode/instances](https://developers.linode.com/api/v4/linode-instances))
+  * `Create Linode` ([PUT /linode/instances](https://developers.linode.com/api/v4/linode-instances/#post))
+  * `View Linode` ([GET /linode/instances/{linodeId}](https://developers.linode.com/api/v4/linode-instances-linode-id))
+  * `Update Linode` ([PUT /linode/instances/{linodeId}](https://developers.linode.com/api/v4/linode-instances-linode-id/#put))
+  * `Rebuild Linode` ([POST /linode/instances/{linodeId}/rebuild](https://developers.linode.com/api/v4/linode-instances-linode-id-rebuild/#post))
 * Added end of life to image endpoints. This displays the image's distribution's planned end of life. This `eol` response parameter has been added to the following endpoints:
   * List Images ([GET /images](https://developers.linode.com/api/v4/images)])
   * Create Image ([POST /images](https://developers.linode.com/api/v4/images#post))

--- a/src/content/changelog/4-11-0-2019-12-16.md
+++ b/src/content/changelog/4-11-0-2019-12-16.md
@@ -17,5 +17,5 @@ changelog:
 * Added end of life to image endpoints. This displays the image's distribution's planned end of life. This `eol` response parameter has been added to the following endpoints:
   * List Images ([GET /images](https://developers.linode.com/api/v4/images))
   * Create Image ([POST /images](https://developers.linode.com/api/v4/images#post))
-  * View Image ([(GET /images/:imageId)](https://developers.linode.com/api/v4/images-image-id))
-  * Update Image ([(PUT /images/:imageId)](https://developers.linode.com/api/v4/images-image-id#put))
+  * View Image ([(GET /images/{imageId})](https://developers.linode.com/api/v4/images-image-id))
+  * Update Image ([(PUT /images/{imageId})](https://developers.linode.com/api/v4/images-image-id#put))

--- a/src/content/changelog/4-11-0-2019-12-16.md
+++ b/src/content/changelog/4-11-0-2019-12-16.md
@@ -7,15 +7,15 @@ changelog:
 ---
 ### Added
 
-* The `View Account` ([GET /account](https://developers.linode.com/api/v4/account)) and the `Update Account` ([PUT /account](https://developers.linode.com/api/v4/account/#put)) endpoints have been updated to include a new field `euuid`. This field is an external unique identifier for this customer.
+* The View Account ([GET /account](https://developers.linode.com/api/v4/account)) and the Update Account ([PUT /account](https://developers.linode.com/api/v4/account/#put)) endpoints have been updated to include a new field `euuid`. This field is an external unique identifier for this customer.
 * The following endpoints have the new field `last_successful` adedd to the `backups` envelope within the `Linode` object. This field is the date and time of the last successful backup if there was one. If there was no backup, 'null' is shown.
-  * `List Linodes` ([GET /linode/instances](https://developers.linode.com/api/v4/linode-instances))
-  * `Create Linode` ([POST /linode/instances](https://developers.linode.com/api/v4/linode-instances/#post))
-  * `View Linode` ([GET /linode/instances/{linodeId}](https://developers.linode.com/api/v4/linode-instances-linode-id))
-  * `Update Linode` ([PUT /linode/instances/{linodeId}](https://developers.linode.com/api/v4/linode-instances-linode-id/#put))
-  * `Rebuild Linode` ([POST /linode/instances/{linodeId}/rebuild](https://developers.linode.com/api/v4/linode-instances-linode-id-rebuild/#post))
+  * List Linodes ([GET /linode/instances](https://developers.linode.com/api/v4/linode-instances))
+  * Create Linode ([POST /linode/instances](https://developers.linode.com/api/v4/linode-instances/#post))
+  * View Linode ([GET /linode/instances/{linodeId}](https://developers.linode.com/api/v4/linode-instances-linode-id))
+  * Update Linode ([PUT /linode/instances/{linodeId}](https://developers.linode.com/api/v4/linode-instances-linode-id/#put))
+  * Rebuild Linode ([POST /linode/instances/{linodeId}/rebuild](https://developers.linode.com/api/v4/linode-instances-linode-id-rebuild/#post))
 * Added end of life to image endpoints. This displays the image's distribution's planned end of life. This `eol` response parameter has been added to the following endpoints:
   * List Images ([GET /images](https://developers.linode.com/api/v4/images))
   * Create Image ([POST /images](https://developers.linode.com/api/v4/images#post))
-  * View Image [(GET /images/:imageId)](https://developers.linode.com/api/v4/images-image-id)
-  * Update Image [(PUT /images/:imageId)](https://developers.linode.com/api/v4/images-image-id#put)
+  * View Image ([(GET /images/:imageId)](https://developers.linode.com/api/v4/images-image-id))
+  * Update Image ([(PUT /images/:imageId)](https://developers.linode.com/api/v4/images-image-id#put))

--- a/src/content/changelog/cloud-manager-0-80-0.md
+++ b/src/content/changelog/cloud-manager-0-80-0.md
@@ -1,0 +1,49 @@
+---
+title: Cloud Manager 0.80.0
+date: 2019-12-17T05:00:00.000Z
+version: 0.80.0
+changelog:
+  - Cloud Manager
+---
+
+### Added:
+
+* Remove check zone from domain action menu
+* Move sidebar in Domains detail
+* Duration time to Events Landing and Activity Feed
+* Display billing notice when deleting last Object Storage Bucket
+* Longview:
+  * Landing page
+  * Overview page
+  * Installation page
+  * Enable client sorting on Landing page
+  * Packages drawer
+
+* New One-Click Apps:
+  * Docker
+  * Jenkins
+  * Grafana
+  * Prometheus
+  * MySQL
+  * LEMP Stack
+  * Shadowsocks
+
+### Changed:
+
+- Remove ZXCVBN and improve password hints
+- Remove (disabled) Check Zone and Zone File actions from Domains
+- LKE added to PAT Scopes
+- Make search bar case-insensitive
+- Option to show all Linodes on Linode Landing
+- Remove same-domain SOA email restriction (client-side validation)
+- Update release docs
+- Styling adjustment to IconTextLink
+
+### Fixed:
+
+- Accessibility features overhaul
+- Update Object Storage icon color
+- Error formatting on editable input labels
+- Event badge hidden behind scrollbar
+- Linode status not updated after resizing is complete
+- State not responding to Longview events

--- a/src/content/changelog/cloud-manager-0-81-0.md
+++ b/src/content/changelog/cloud-manager-0-81-0.md
@@ -1,0 +1,23 @@
+---
+title: Cloud Manager 0.81.0
+date: 2019-12-19T05:00:00.000Z
+version: 0.81.0
+changelog:
+  - Cloud Manager
+---
+
+### Added:
+
+- Longview:
+  - Display non-error Notifications from Longview API on Longview Details page
+  - Empty and loading states for Overview graphs
+
+### Changed:
+
+- Use “Last Backup” data on /linode/instances endpoint to avoid multiple requests to /backups (improves performance)
+- Show deprecated label for distros in Images dropdown
+
+### Fixed:
+
+- Display invoice PDF total, tax, and amount values in \$0.00 format
+- Reduce OCA tile spacing between icon and label

--- a/src/content/changelog/cloud-manager-0-81.1.md
+++ b/src/content/changelog/cloud-manager-0-81.1.md
@@ -1,0 +1,10 @@
+---
+title: Cloud Manager 0.81.1
+date: 2019-12-23T05:00:00.000Z
+version: 0.81.1
+changelog:
+  - Cloud Manager
+---
+
+### Changed:
+- Update error reporting to reduce unnecessary reports


### PR DESCRIPTION
* Cloud Manger changelogs 0.81.1, 0.81.0, and 0.80.0
* API changelog 4.11.0 link fixes and copy edits
* Remove APIv3 sidebar menu item