### PR TITLE
build site with development spec on development

### DIFF
--- a/getDependencies.sh
+++ b/getDependencies.sh
@@ -1,5 +1,12 @@
+#!/usr/bin/env bash
+
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
+
+SPEC_BRANCH="master"
+if [[ "$GIT_LOCAL_BRANCH" =~ ^(master|development)$ ]]; then
+  SPEC_BRANCH="${GIT_LOCAL_BRANCH}"
+fi
 
 SPEC_FILE=""
 if [ -n ${1} ]; then
@@ -24,7 +31,7 @@ else
   echo
   printf "${BLUE}Fetching API specs${NC}\n"
   cd -
-  curl https://raw.githubusercontent.com/linode/linode-api-docs/master/openapi.yaml > static/api/docs/v4/openapi.yaml;
+  curl "https://raw.githubusercontent.com/linode/linode-api-docs/${SPEC_BRANCH}/openapi.yaml" > static/api/docs/v4/openapi.yaml;
 fi
 
 echo


### PR DESCRIPTION
This change adds a check for the Jenkins `GIT_LOCAL_BRANCH` environment
variable [[1]], and then pulls the spec accordingly.

`master` pulls `master` from:
https://raw.githubusercontent.com/linode/linode-api-docs/master/openapi.yaml

`development` pulls `development`from:
https://raw.githubusercontent.com/linode/linode-api-docs/development/openapi.yaml

Any others, default to `master`.

[1]: https://github.com/jenkinsci/git-plugin#environment-variables