### PR TITLE
Changelog for JS client v0.27.1-alpha.0

### DIFF
--- a/src/content/changelog/js-client-changelog-0-27-1-alpha-0.md
+++ b/src/content/changelog/js-client-changelog-0-27-1-alpha-0.md
@@ -1,0 +1,11 @@
+---
+title: Linode APIv4 JS Client
+date: 2020-06-03T05:00:00.000Z
+version: 0.27.1-alpha.0
+changelog:
+  - Cloud Manager
+---
+
+### Fixed
+
+- Remove required from createDomain validation schema


### PR DESCRIPTION
This is the first time we've released a change to the JS client without making changes to Cloud Manager itself. As @Jskobos noted, we may eventually want this as a separate category altogether.

![Screen Shot 2020-06-03 at 10 41 10 AM](https://user-images.githubusercontent.com/16911484/83651028-061db680-a587-11ea-9c1c-4bd2bb5156fe.png)
