### PR TITLE
[Birthday] Footer Change - remove Nanode update Standard to Shared

### DIFF
--- a/src/components/3_organisms/footer-nav.js
+++ b/src/components/3_organisms/footer-nav.js
@@ -84,7 +84,7 @@ const FooterNav = () => (
           </li>
           <li>
             <a href="https://linode.com/products/shared-linodes/">
-              Shared Linodes
+              Shared
             </a>
           </li>
           <li>

--- a/src/components/3_organisms/footer-nav.js
+++ b/src/components/3_organisms/footer-nav.js
@@ -83,11 +83,8 @@ const FooterNav = () => (
             <a href="https://linode.com/products/kubernetes/">Kubernetes</a>
           </li>
           <li>
-            <a href="https://linode.com/products/nanodes/">Nanodes</a>
-          </li>
-          <li>
-            <a href="https://linode.com/products/standard-linodes/">
-              Standard Linodes
+            <a href="https://linode.com/products/shared-linodes/">
+              Shared Linodes
             </a>
           </li>
           <li>

--- a/src/components/3_organisms/footer-nav.js
+++ b/src/components/3_organisms/footer-nav.js
@@ -83,7 +83,7 @@ const FooterNav = () => (
             <a href="https://linode.com/products/kubernetes/">Kubernetes</a>
           </li>
           <li>
-            <a href="https://linode.com/products/shared-linodes/">
+            <a href="https://linode.com/products/shared/">
               Shared
             </a>
           </li>

--- a/src/components/3_organisms/footer-nav.js
+++ b/src/components/3_organisms/footer-nav.js
@@ -88,13 +88,13 @@ const FooterNav = () => (
             </a>
           </li>
           <li>
-            <a href="https://linode.com/products/high-memory/">
-              High Memory Linodes
+            <a href="https://linode.com/products/dedicated-cpu/">
+              Dedicated CPU
             </a>
           </li>
           <li>
-            <a href="https://linode.com/products/dedicated-cpu/">
-              Dedicated CPU
+            <a href="https://linode.com/products/high-memory/">
+              High Memory Linodes
             </a>
           </li>
           <li>

--- a/src/components/3_organisms/footer-nav.js
+++ b/src/components/3_organisms/footer-nav.js
@@ -77,7 +77,7 @@ const FooterNav = () => (
         <h4 className="footer-nav-header">Products</h4>
         <ul className="footer-sublist">
           <li>
-            <a href="https://linode.com/products/">Products</a>
+            <a href="https://linode.com/products/">Products Overview</a>
           </li>
           <li>
             <a href="https://linode.com/products/kubernetes/">Kubernetes</a>

--- a/src/components/3_organisms/footer-nav.js
+++ b/src/components/3_organisms/footer-nav.js
@@ -94,7 +94,7 @@ const FooterNav = () => (
           </li>
           <li>
             <a href="https://linode.com/products/high-memory/">
-              High Memory Linodes
+              High Memory
             </a>
           </li>
           <li>


### PR DESCRIPTION
Birthday footer change. Header will update with WP API change.