### PR TITLE
[Update] API Changelog 4.68.0

### DIFF
--- a/src/content/changelog/4-68-0-2020-06-29.md
+++ b/src/content/changelog/4-68-0-2020-06-29.md
@@ -33,10 +33,16 @@ https://api.linode.com/v4/profile/logins) and [GET /profile/logins/{loginId}](ht
 
     - Review your Account's Events with the List Events ([GET /account/events](https://developers.linode.com/api/v4/account-events)) endpoint.
 
-    - Use the View Config ([GET /nodebalancers/{nodeBalancerId}/configs/{configId}](https://developers.linode.com/api/v4/nodebalancers-node-balancer-id-configs-config-id)) endpoint to review the Config from one of these events.
+    - Use the View Config ([GET /nodebalancers/{nodeBalancerId}/configs/{configId}](https://developers.linode.com/api/v4/nodebalancers-node-balancer-id-configs-config-id)) endpoint
+    to review the Config from one of these events.
+
+- The `address` field for Create Managed Service ([POST/managed/services](/api/v4/managed-services/#post)) and Update Managed Service ([PUT /managed/services/{serviceId}](/api/v4/managed-services-service-id/#put)) now accepts additional special characters for a service that is monitored by URL (`"service_type" : "url"`).
+
 
 ### Fixed
 
 - The Domains ([/domains](https://developers.linode.com/api/v4/domains)) collection previously accepted values up to 255 for the `weight` property of a Record, while 65535 was the intended maximum. Values up to 65535 are now considered valid.
 
 - The Domains ([/domains](https://developers.linode.com/api/v4/domains)) collection previously returned a generic syntax error whenever a TXT Record was submitted with non-ASCII characters. It will now return a more specific validation error.
+
+- A bug was fixed that was preventing restricted users with the appropriate access permissions for specific Linode services from adding [Tags](/api/v4/tags/#post) to those services.


### PR DESCRIPTION
* Add missing changelog entries from release 4.68.0
  * Managed Services `address` field validations
  * Restricted users bug related to adding tags to Linode services