### PR TITLE
Fix typo on 2 files under src/content/changelog/

### DIFF
--- a/src/content/changelog/06-17-api.md
+++ b/src/content/changelog/06-17-api.md
@@ -19,4 +19,4 @@ version: 4.1.0
 ### Fixed
 
 - Fixed failing validation for Internationalized Domain Names (IDN).
-- When using the the View Linode endpoint ([GET /linode/instances/{linodeId}](https://developers.linode.com/api/v4/linode-instances-linode-id)) Linodes that have not been assigned an IPv6 address will have their JSON correctly display *null*.
+- When using the View Linode endpoint ([GET /linode/instances/{linodeId}](https://developers.linode.com/api/v4/linode-instances-linode-id)) Linodes that have not been assigned an IPv6 address will have their JSON correctly display *null*.

--- a/src/content/changelog/08-12-api.md
+++ b/src/content/changelog/08-12-api.md
@@ -11,7 +11,7 @@ version: 4.3.0
 
 - Added a new View Managed SSH Key ([GET /managed/credentials/sshkey](https://developers.linode.com/api/v4/managed-credentials-sshkey)) endpoint. This endpoint returns the unique SSH public key assigned to your Linode account's [Managed service](https://www.linode.com/managed). If you [add this public key](https://linode.com/docs/platform/linode-managed/#adding-the-public-key) to a Linode on your account, Linode special forces will be able to log in to the Linode with this key when attempting to resolve issues.
 
-- Added additional filtering for Events. Events returned by the the List Events ([GET /account/events](https://developers.linode.com/api/v4/account-events)) endpoint can be filtered by an Event entity's _id_ and _type_.
+- Added additional filtering for Events. Events returned by the List Events ([GET /account/events](https://developers.linode.com/api/v4/account-events)) endpoint can be filtered by an Event entity's _id_ and _type_.
 
   There are a few edge cases when filtering Events by entity ID:
 


### PR DESCRIPTION
`s/the the /the /g`