### PR TITLE
Add Cloud Manager and JS Client changelog entries

### DIFF
--- a/src/content/changelog/cloud-manager-version-1-21-0.md
+++ b/src/content/changelog/cloud-manager-version-1-21-0.md
@@ -1,0 +1,18 @@
+---
+title: Cloud Manager v1.21.0
+date: 2020-09-29T05:00:00.000Z
+version: 1.21.0
+changelog:
+  - Cloud Manager
+---
+
+### Added:
+
+One-Click Apps:
+
+- Jitsi
+- Webmin
+- Virtualmin
+- Plex
+- phpMyAdmin
+- Azuracast

--- a/src/content/changelog/cloud-manager-version-1-22-1.md
+++ b/src/content/changelog/cloud-manager-version-1-22-1.md
@@ -1,0 +1,11 @@
+---
+title: Cloud Manager v1.22.1
+date: 2020-10-13T05:00:00.000Z
+version: 1.22.1
+changelog:
+  - Cloud Manager
+---
+
+### Changed:
+
+- Make CVV required when adding a credit card

--- a/src/content/changelog/cloud-manager-version-1-23-0.md
+++ b/src/content/changelog/cloud-manager-version-1-23-0.md
@@ -1,0 +1,44 @@
+---
+title: Cloud Manager v1.23.0
+date: 2020-10-20T05:00:00.000Z
+version: 1.23.0
+changelog:
+  - Cloud Manager
+---
+
+### Added:
+
+VLAN:
+
+- Landing table
+- Details table
+- Linode Networking panel
+- Attach and detach Linode to VLAN drawer
+
+CMR:
+
+- Banner for open abuse tickets
+
+### Changed:
+
+- Request Domains on load to determine account size
+- Update dark theme styling
+- Add helper text for NodeBalancer Proxy Protocol field
+- Add tooltip for sort in Notifications drawer
+
+### Fixed:
+
+VLAN:
+
+- Attach Linode drawer fixes
+
+CMR:
+
+- Wide table width with overflow when cloning Linodes
+- Fix Lish link
+- Sync animations for pending actions
+- Remove underscores in Linode statuses in LinodeEntityDetail
+
+- Long Domain records overflowing table rows
+- Incorrect flag shown for Sydney in Linode Migrate
+- Search results not displaying for some restricted users

--- a/src/content/changelog/js-client-changelog-0-36-0.md
+++ b/src/content/changelog/js-client-changelog-0-36-0.md
@@ -1,0 +1,11 @@
+---
+title: Linode APIv4 JS Client v0.36.0
+date: 2020-10-20T05:00:00.000Z
+version: 0.36.0
+changelog:
+  - APIv4 JS Client
+---
+
+### Changed:
+
+- Update VLAN Linodes typing


### PR DESCRIPTION
This adds the most recent Cloud Manager and JS Client changelog entries:

- Cloud v1.23.0
- JS Client v0.36.0

I also added two missing Cloud Manager changelog entries:

- Cloud v1.22.1
- Cloud v1.21.0