### PR TITLE
Prismjs version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "netlify-cms-app": "^2.9.1",
     "netlify-cms-widget-inline-select": "^1.3.1",
     "postcss-easy-import": "^3.0.0",
+    "prismjs": ">=1.21.0",
     "prop-types": "^15.6.2",
     "react": "^16.7.0",
     "react-clipboard.js": "^2.0.7",
@@ -69,6 +70,7 @@
     "dotenv": "^8.0.0",
     "lodash": "^4.17.19",
     "md5": "^2.2.1",
+    "prismjs": ">=1.21.0",
     "randomstring": "^1.1.5",
     "yamljs": "^0.3.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13046,7 +13046,7 @@ pretty-hrtime@^1.0.3:
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
 
-prismjs@^1.8.4:
+prismjs@>=1.21.0, prismjs@^1.8.4:
   version "1.22.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.22.0.tgz#73c3400afc58a823dd7eed023f8e1ce9fd8977fa"
   integrity sha512-lLJ/Wt9yy0AiSYBf212kK3mM5L8ycwlyTlSxHBAneXLR0nzFMlZ5y7riFPF3E33zXOF2IH95xdY5jIyZbM9z/w==


### PR DESCRIPTION
dependabot alerted the repo to a high serverity vuln fixed in
the latest prismjs version.