### PR TITLE
API Changelog 4.81.0

### DIFF
--- a/src/content/changelog/4-81-0-2020-12-02.md
+++ b/src/content/changelog/4-81-0-2020-12-02.md
@@ -16,3 +16,5 @@ changelog:
 - [OAuth Reference](/docs/api/#oauth-reference) has been updated to include Firewall, Maintenance, and Object Storage security scopes.
 
 - The OAuth scope for the [Event Mark as Seen](/docs/api/account/#event-mark-as-seen) (POST /account/events/{eventId}/seen) endpoint has been corrected to `events:read_write`. Previously, it was stated as `events:read_only`.
+
+- The OAuth scope for the [Firewalls List](/docs/api/networking/#firewalls-list) (GET /networking/firewalls) endpoint has been correct to `firewall:read_only`. Previously, it was stated as `firewalls:read_only`.

--- a/src/content/changelog/4-81-0-2020-12-02.md
+++ b/src/content/changelog/4-81-0-2020-12-02.md
@@ -1,0 +1,14 @@
+---
+title: '4.81.0: 2020-12-02'
+date: 2020-12-02T04:00:00.000Z
+version: 4.81.0
+changelog:
+  - API
+---
+
+### Fixed
+
+- A bug was fixed to allow preservation of URL parameters for service monitor addresses set at the following endpoints:
+
+  - [Managed Service Create](/docs/api/managed/#managed-service-create) (POST /managed/services)
+  - [Managed Service Update](/docs/api/managed/#managed-service-update) (PUT /managed/services/{serviceId})

--- a/src/content/changelog/4-81-0-2020-12-02.md
+++ b/src/content/changelog/4-81-0-2020-12-02.md
@@ -15,6 +15,6 @@ changelog:
 
 - [OAuth Reference](/docs/api/#oauth-reference) has been updated to include Firewall, Maintenance, and Object Storage security scopes.
 
-- The OAuth scope for the [Event Mark as Seen](/docs/api/account/#event-mark-as-seen) (POST /account/events/{eventId}/seen) endpoint has been corrected to `events:read_write`. Previously, it was stated as `events:read_only`.
+- The `x-linode-grant` for the [Event Mark as Seen](/docs/api/account/#event-mark-as-seen) (POST /account/events/{eventId}/seen) endpoint has been corrected to `read_only`. Previously, it was stated as `read_write`.
 
 - The OAuth scope for the [Firewalls List](/docs/api/networking/#firewalls-list) (GET /networking/firewalls) endpoint has been correct to `firewall:read_only`. Previously, it was stated as `firewalls:read_only`.

--- a/src/content/changelog/4-81-0-2020-12-02.md
+++ b/src/content/changelog/4-81-0-2020-12-02.md
@@ -12,3 +12,7 @@ changelog:
 
   - [Managed Service Create](/docs/api/managed/#managed-service-create) (POST /managed/services)
   - [Managed Service Update](/docs/api/managed/#managed-service-update) (PUT /managed/services/{serviceId})
+
+- [OAuth Reference](/docs/api/#oauth-reference) has been updated to include Firewall, Maintenance, and Object Storage security scopes.
+
+- The OAuth scope for the [Event Mark as Seen](/docs/api/account/#event-mark-as-seen) (POST /account/events/{eventId}/seen) endpoint has been corrected to `events:read_write`. Previously, it was stated as `events:read_only`.

--- a/src/content/changelog/4-81-0-2020-12-02.md
+++ b/src/content/changelog/4-81-0-2020-12-02.md
@@ -15,9 +15,6 @@ changelog:
 
 - [OAuth Reference](/docs/api/#oauth-reference) has been updated to include Firewall, Maintenance, and Object Storage security scopes.
 
-<<<<<<< HEAD
 - The `x-linode-grant` for the [Event Mark as Seen](/docs/api/account/#event-mark-as-seen) (POST /account/events/{eventId}/seen) endpoint has been corrected to `read_only`. Previously, it was stated as `read_write`.
 
-=======
->>>>>>> 04b99b2a06162acf4767b03827fdb3c016b3db98
 - The OAuth scope for the [Firewalls List](/docs/api/networking/#firewalls-list) (GET /networking/firewalls) endpoint has been correct to `firewall:read_only`. Previously, it was stated as `firewalls:read_only`.

--- a/src/content/changelog/4-81-0-2020-12-02.md
+++ b/src/content/changelog/4-81-0-2020-12-02.md
@@ -15,6 +15,4 @@ changelog:
 
 - [OAuth Reference](/docs/api/#oauth-reference) has been updated to include Firewall, Maintenance, and Object Storage security scopes.
 
-- The OAuth scope for the [Event Mark as Seen](/docs/api/account/#event-mark-as-seen) (POST /account/events/{eventId}/seen) endpoint has been corrected to `events:read_write`. Previously, it was stated as `events:read_only`.
-
 - The OAuth scope for the [Firewalls List](/docs/api/networking/#firewalls-list) (GET /networking/firewalls) endpoint has been correct to `firewall:read_only`. Previously, it was stated as `firewalls:read_only`.


### PR DESCRIPTION
### Fixed

- A bug was fixed to allow preservation of URL parameters for service monitor addresses set at the following endpoints:

  - [Managed Service Create](https://www.linode.com/docs/api/managed/#managed-service-create) (POST /managed/services)
  - [Managed Service Update](https://www.linode.com/docs/api/managed/#managed-service-update) (PUT /managed/services/{serviceId})

- [OAuth Reference](https://www.linode.com/docs/api/#oauth-reference) has been updated to include Firewall, Maintenance, and Object Storage security scopes.

- The `x-linode-grant` for the [Event Mark as Seen](https://www.linode.com/docs/api/account/#event-mark-as-seen) (POST /account/events/{eventId}/seen) endpoint has been corrected to `read_only`. Previously, it was stated as `read_write`.

- The OAuth scope for the [Firewalls List](https://www.linode.com/docs/api/networking/#firewalls-list) (GET /networking/firewalls) endpoint has been correct to `firewall:read_only`. Previously, it was stated as `firewalls:read_only`.
