### PR TITLE
ref: Stop suggesting python2 for linode-cli

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -20,10 +20,10 @@ const IndexPage = () => {
             All of the functionality of the Manager from the command line.
           </div>
           <CodeBox
-            line1="pip install linode-cli"
+            line1="pip3 install linode-cli"
             line2="linode-cli linodes create"
           />
-          {/* {{ partial "2_molecules/code-box.html" ( dict "Line1" "pip install linode-cli" "Line2" "linode-cli linodes create") }} */}
+          {/* {{ partial "2_molecules/code-box.html" ( dict "Line1" "pip3 install linode-cli" "Line2" "linode-cli linodes create") }} */}
           <div className="mt-6 text-center">
             <a
               href="https://www.linode.com/cli"

--- a/src/pages/libraries-tools.js
+++ b/src/pages/libraries-tools.js
@@ -26,10 +26,10 @@ const LibToolsPage = () => {
               <div className="px-4 flex flex-wrap">
                 <div style={{ width: 300 }}>
                   <CodeBox
-                    line1="pip install linode-cli"
+                    line1="pip3 install linode-cli"
                     line2="linode-cli linodes create"
                   />
-                  {/* {{ partial "2_molecules/code-box.html" ( dict "Line1" "pip install linode-cli" "Line2" "linode-cli linodes create") }} */}
+                  {/* {{ partial "2_molecules/code-box.html" ( dict "Line1" "pip3 install linode-cli" "Line2" "linode-cli linodes create") }} */}
                 </div>
                 <div className="mt-4 md:hidden flex w-full justify-center">
                   <a


### PR DESCRIPTION
Python 2 has been EOL since 2020, and I'd like to work toward dropping
support for it.  An easy first step would be to stop suggesting users
install the linode-cli with python2.

This change makes all suggested `pip install linode-cli` operations into
`pip3 install linode-cli`.
