### PR TITLE
Add adobe launch tag / use environment variables to configure tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ typings/
 
 # dotenv environment variables file
 .env
+.env.*
 
 # gatsby files
 .cache/

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,3 +1,7 @@
+require("dotenv").config({
+  path: `.env.${process.env.NODE_ENV}`,
+})
+
 module.exports = {
   siteMetadata: {
     title: `Linode Developer Tools`,
@@ -25,11 +29,11 @@ module.exports = {
     {
       resolve: "gatsby-plugin-google-tagmanager",
       options: {
-        id: "GTM-T5FXXG9",
+        id: ( process.env.GTM_CONTAINER_ID || 'GTM-T5FXXG9' ),
 
         // Include GTM in development.
         // Defaults to false meaning GTM will only be loaded in production.
-        includeInDevelopment: false,
+        includeInDevelopment: true,
 
         // datalayer to be set before GTM is loaded
         // should be an object or a function that is executed in the browser

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -29,7 +29,7 @@ module.exports = {
     {
       resolve: "gatsby-plugin-google-tagmanager",
       options: {
-        id: ( process.env.GTM_CONTAINER_ID || 'GTM-T5FXXG9' ),
+        id: process.env.GTM_CONTAINER_ID,
 
         // Include GTM in development.
         // Defaults to false meaning GTM will only be loaded in production.

--- a/src/html.js
+++ b/src/html.js
@@ -2,6 +2,8 @@ import React from "react";
 import favicon from "./images/favicon.ico";
 
 function HTML(props) {
+  const adobe_launch_id = process.env.GATSBY_ADOBE_LAUNCH_ID;
+  const adobe_launch_tag = adobe_launch_id ? <script src={`https://assets.adobedtm.com/fcfd3580c848/f9e7661907ee/launch-${adobe_launch_id}.min.js`} async></script> : '';
   return (
     <html lang="en">
       <head>
@@ -18,6 +20,7 @@ function HTML(props) {
         <link id="theme__google-fonts-css" href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&family=Oswald:wght@300;400&display=swap" rel="stylesheet"></link>
         <script src="https://kit.fontawesome.com/07f951a406.js" crossOrigin="anonymous"></script>
         <script async="async" src="//consent.trustarc.com/notice?domain=linode.com&c=teconsent&js=nj&noticeType=bb&text=true&gtm=1" crossOrigin=""></script>
+        {adobe_launch_tag}
       </head>
       <body>
         <div


### PR DESCRIPTION
Adds adobe launch tag in a way that we can use Gatsby environment variables to configure it. For this to work, we also need to get the environment variables set in the production build process.