### PR TITLE
Release 1.1.137

### DIFF
--- a/src/components/5_templates/api.js
+++ b/src/components/5_templates/api.js
@@ -247,7 +247,6 @@ export const query = graphql`
             summary
             description
             operationId
-            x_linode_cli_action
             x_linode_cli_skip
             x_linode_redoc_load_ids
             x_linode_cli_command
@@ -326,7 +325,6 @@ export const query = graphql`
             tags
             description
             operationId
-            x_linode_cli_action
             x_linode_cli_command
             x_linode_charge
             x_linode_cli_skip
@@ -412,7 +410,6 @@ export const query = graphql`
             tags
             description
             operationId
-            x_linode_cli_action
             x_linode_cli_skip
             security {
               oauth
@@ -493,7 +490,6 @@ export const query = graphql`
             summary
             description
             operationId
-            x_linode_cli_action
             x_linode_grant
             security {
               oauth

--- a/src/components/5_templates/api.js
+++ b/src/components/5_templates/api.js
@@ -119,7 +119,6 @@ class apiPage extends React.Component {
                           escapeHtml={false}
                           className="my-8 api-desc"
                         />
-                        {m.security && <Security oauth={m.security[1].oauth} />}
                         {n.parameters && (
                           <div className="my-8">
                             <h3 className="mb-2">Path Parameters</h3>

--- a/src/content/changelog/4-140-0-2022-11-14.md
+++ b/src/content/changelog/4-140-0-2022-11-14.md
@@ -13,3 +13,5 @@ changelog:
 ### Fixed
 
 * Fixed a bug that caused a Volume's `linode_label` to return as `null` in the response for **Volume Resize** ([POST /volumes/{volumeId}/resize](https://www.linode.com/docs/api/volumes/#volume-resize)) and for all Volumes beyond the first when attached to the same Linode for **Volumes List** ([GET /volumes](https://www.linode.com/docs/api/volumes/#volumes-list)). Now, `linode_label` always displays the correct value in responses for these commands.
+
+* Fixed a bug that caused extra Configs to persist after accessing the **Linode Boot into Rescue Mode** ([POST /linode/instances/{linodeId}/rescue](https://www.linode.com/docs/api/linode-instances/#linode-boot-into-rescue-mode)) command. Now, only the most recent rescue Config persists after booting into rescue mode.

--- a/src/content/changelog/4-140-0-2022-11-14.md
+++ b/src/content/changelog/4-140-0-2022-11-14.md
@@ -1,0 +1,15 @@
+---
+title: '4.140.0: 2022-11-14'
+date: 2022-11-14T01:00:00.000Z
+version: 4.140.0
+changelog:
+  - API
+---
+
+### Changed
+
+* [Linode Instances](https://www.linode.com/docs/api/linode-instances/) and their [Backups](https://www.linode.com/docs/api/linode-instances/#backups-list) now include the "available" read-only property which indicates whether a Linode's Backups are available for restoration. Backups that are undergoing maintenance are not available for restoration.
+
+### Fixed
+
+* Fixed a bug that caused a Volume's `linode_label` to return as `null` in the response for **Volume Resize** ([POST /volumes/{volumeId}/resize](https://www.linode.com/docs/api/volumes/#volume-resize)) and for all Volumes beyond the first when attached to the same Linode for **Volumes List** ([GET /volumes](https://www.linode.com/docs/api/volumes/#volumes-list)). Now, `linode_label` always displays the correct value in responses for these commands.

--- a/yarn.lock
+++ b/yarn.lock
@@ -5215,9 +5215,9 @@ debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.6, debug@^3.2.7:
     ms "^2.1.1"
 
 debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@~4.3.1:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
-  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
 
@@ -15785,9 +15785,9 @@ socket.io-client@3.1.1:
     socket.io-parser "~4.0.4"
 
 socket.io-parser@~4.0.3, socket.io-parser@~4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.0.4.tgz#9ea21b0d61508d18196ef04a2c6b9ab630f4c2b0"
-  integrity sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.0.5.tgz#cb404382c32324cc962f27f3a44058cf6e0552df"
+  integrity sha512-sNjbT9dX63nqUFIOv95tTVm6elyIU4RvB1m8dOeZt+IgWwcWklFDOdmGcfo3zSiRsnR/3pJkjY5lfoGqEe4Eig==
   dependencies:
     "@types/component-emitter" "^1.2.10"
     component-emitter "~1.3.0"


### PR DESCRIPTION
### Added
- API v4.140.0 Changelog

### Fixed
- Removed breaking background rendering for `x-linode-cli-action` and oauth scopes.
